### PR TITLE
Add missing return value for Command's execute() methods (Symfony >= 4.4)

### DIFF
--- a/src/Command/DoctrineDecryptDatabaseCommand.php
+++ b/src/Command/DoctrineDecryptDatabaseCommand.php
@@ -33,7 +33,7 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Get entity manager, question helper, subscriber service and annotation reader
         $question = $this->getHelper('question');
@@ -82,7 +82,7 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
         );
 
         if (!$question->ask($input, $output, $confirmationQuestion)) {
-            return 1;
+            return self::FAILURE;
         }
 
         // Start decrypting database
@@ -146,5 +146,6 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
         }
 
         $output->writeln('' . PHP_EOL . 'Decryption finished values found: <info>' . $valueCounter . '</info>, decrypted: <info>' . $this->subscriber->decryptCounter . '</info>.' . PHP_EOL . 'All values are now decrypted.');
+        return self::SUCCESS;
     }
 }

--- a/src/Command/DoctrineEncryptDatabaseCommand.php
+++ b/src/Command/DoctrineEncryptDatabaseCommand.php
@@ -32,7 +32,7 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // Get entity manager, question helper, subscriber service and annotation reader
         $question = $this->getHelper('question');
@@ -69,7 +69,7 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
         );
 
         if (!$question->ask($input, $output, $confirmationQuestion)) {
-            return 1;
+            return self::FAILURE;
         }
 
         // Start decrypting database
@@ -101,6 +101,7 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
 
         // Say it is finished
         $output->writeln('Encryption finished. Values encrypted: <info>' . $this->subscriber->encryptCounter . ' values</info>.' . PHP_EOL . 'All values are now encrypted.');
+        return self::SUCCESS;
     }
 
 

--- a/src/Command/DoctrineEncryptStatusCommand.php
+++ b/src/Command/DoctrineEncryptStatusCommand.php
@@ -27,7 +27,7 @@ class DoctrineEncryptStatusCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $metaDataArray = $this->entityManager->getMetadataFactory()->getAllMetadata();
 
@@ -53,5 +53,6 @@ class DoctrineEncryptStatusCommand extends AbstractCommand
 
         $output->writeln('');
         $output->writeln(sprintf('<info>%d</info> entities found which are containing <info>%d</info> encrypted properties.', count($metaDataArray), $totalCount));
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
Fixes:
> Return value of "Ambta\DoctrineEncryptBundle\Command\DoctrineEncryptStatusCommand::execute()" must be of the type int, "null" returned.
when using Symfony 5

Similar to https://github.com/GiveMeAllYourCats/DoctrineEncryptBundle/pull/41 with the reviewers' suggestions implemented.