### PR TITLE
Update for Symfony 4.4+

### DIFF
--- a/src/Command/DoctrineDecryptDatabaseCommand.php
+++ b/src/Command/DoctrineDecryptDatabaseCommand.php
@@ -146,5 +146,7 @@ class DoctrineDecryptDatabaseCommand extends AbstractCommand
         }
 
         $output->writeln('' . PHP_EOL . 'Decryption finished values found: <info>' . $valueCounter . '</info>, decrypted: <info>' . $this->subscriber->decryptCounter . '</info>.' . PHP_EOL . 'All values are now decrypted.');
+        
+        return 0;
     }
 }

--- a/src/Command/DoctrineEncryptDatabaseCommand.php
+++ b/src/Command/DoctrineEncryptDatabaseCommand.php
@@ -101,7 +101,7 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
 
         // Say it is finished
         $output->writeln('Encryption finished. Values encrypted: <info>' . $this->subscriber->encryptCounter . ' values</info>.' . PHP_EOL . 'All values are now encrypted.');
+        
+        return 0;
     }
-
-
 }

--- a/src/Command/DoctrineEncryptStatusCommand.php
+++ b/src/Command/DoctrineEncryptStatusCommand.php
@@ -53,5 +53,7 @@ class DoctrineEncryptStatusCommand extends AbstractCommand
 
         $output->writeln('');
         $output->writeln(sprintf('<info>%d</info> entities found which are containing <info>%d</info> encrypted properties.', count($metaDataArray), $totalCount));
+        
+        return 0;
     }
 }


### PR DESCRIPTION
https://symfony.com/doc/4.4/console.html#command-lifecycle

Commands must return an integer used as exit status.